### PR TITLE
Added the options "once" and "strict" to the actions GrowTo* and MoveTo*

### DIFF
--- a/data/rc.xsd
+++ b/data/rc.xsd
@@ -177,6 +177,7 @@
             <xsd:element minOccurs="0" name="linear" type="ob:bool"/>
             <xsd:element minOccurs="0" name="group" type="ob:bool"/>
             <xsd:element minOccurs="0" name="once" type="ob:bool"/>
+            <xsd:element minOccurs="0" name="strict" type="ob:bool"/>
         </xsd:all>
         <xsd:attribute name="name" type="ob:actionname" use="required"/>
     </xsd:complexType>

--- a/data/rc.xsd
+++ b/data/rc.xsd
@@ -176,6 +176,7 @@
             <xsd:element minOccurs="0" name="here" type="ob:bool"/>
             <xsd:element minOccurs="0" name="linear" type="ob:bool"/>
             <xsd:element minOccurs="0" name="group" type="ob:bool"/>
+            <xsd:element minOccurs="0" name="once" type="ob:bool"/>
         </xsd:all>
         <xsd:attribute name="name" type="ob:actionname" use="required"/>
     </xsd:complexType>

--- a/openbox/actions/growtoedge.c
+++ b/openbox/actions/growtoedge.c
@@ -241,7 +241,7 @@ static gboolean run_func(ObActionsData *data, gpointer options)
     }
 
     /* We couldn't grow, so try shrink!
-       Except when on script mode. */
+       Except when on strict mode. */
     if (o->strict)
         return FALSE;
 

--- a/openbox/actions/growtoedge.c
+++ b/openbox/actions/growtoedge.c
@@ -63,6 +63,9 @@ static gpointer setup_func(xmlNodePtr node)
         g_free(s);
     }
 
+    if ((n = obt_xml_find_node(node, "once")))
+        o->once = obt_xml_node_bool(n);
+
     return o;
 }
 
@@ -70,14 +73,9 @@ static gpointer setup_grow_func(xmlNodePtr node)
 {
     Options *o;
 
-    xmlNodePtr n;
-
     o = setup_func(node);
     o->shrink = FALSE;
     o->fill = FALSE;
-
-    if ((n = obt_xml_find_node(node, "once")))
-        o->once = obt_xml_node_bool(n);
 
     return o;
 }
@@ -86,15 +84,9 @@ static gpointer setup_fill_func(xmlNodePtr node)
 {
     Options *o;
 
-    xmlNodePtr n;
-
     o = setup_func(node);
     o->shrink = FALSE;
     o->fill = TRUE;
-    o->once = FALSE;
-
-    if ((n = obt_xml_find_node(node, "once")))
-        o->once = obt_xml_node_bool(n);
 
     return o;
 }
@@ -103,15 +95,9 @@ static gpointer setup_shrink_func(xmlNodePtr node)
 {
     Options *o;
 
-    xmlNodePtr n;
-
     o = setup_func(node);
     o->shrink = TRUE;
     o->fill = FALSE;
-    o->once = FALSE;
-
-    if ((n = obt_xml_find_node(node, "once")))
-        o->once = obt_xml_node_bool(n);
 
     return o;
 }
@@ -225,9 +211,8 @@ static gboolean run_func(ObActionsData *data, gpointer options)
 
         /* If all the edges are blocked, then allow them to jump past their
            current block points. */
-        if (!o->once) {
+        if (!o->once)
             do_grow_all_edges(data, CLIENT_RESIZE_GROW);
-        } 
 
         return FALSE;
     }
@@ -236,17 +221,16 @@ static gboolean run_func(ObActionsData *data, gpointer options)
         gint x, y, w, h;
 
         /* Try grow. */
-        if (o->once) {
+        if (o->once)
             client_find_resize_directional(data->client,
                                        o->dir,
                                        CLIENT_RESIZE_GROW_IF_NOT_ON_EDGE,
                                        &x, &y, &w, &h);
-        } else {
+        else
             client_find_resize_directional(data->client,
                                        o->dir,
                                        CLIENT_RESIZE_GROW,
                                        &x, &y, &w, &h);
-        }
 
         if (do_grow(data, x, y, w, h))
             return FALSE;
@@ -308,10 +292,6 @@ static gpointer setup_north_func(xmlNodePtr node)
     o->dir = OB_DIRECTION_NORTH;
     o->once = FALSE;
 
-    xmlNodePtr n;
-    if ((n = obt_xml_find_node(node, "once")))
-        o->once = obt_xml_node_bool(n);
-
     return o;
 }
 
@@ -321,10 +301,6 @@ static gpointer setup_south_func(xmlNodePtr node)
     o->shrink = FALSE;
     o->dir = OB_DIRECTION_SOUTH;
     o->once = FALSE;
-
-    xmlNodePtr n;
-    if ((n = obt_xml_find_node(node, "once")))
-        o->once = obt_xml_node_bool(n);
 
     return o;
 }
@@ -336,10 +312,6 @@ static gpointer setup_east_func(xmlNodePtr node)
     o->dir = OB_DIRECTION_EAST;
     o->once = FALSE;
 
-    xmlNodePtr n;
-    if ((n = obt_xml_find_node(node, "once")))
-        o->once = obt_xml_node_bool(n);
-
     return o;
 }
 
@@ -349,10 +321,6 @@ static gpointer setup_west_func(xmlNodePtr node)
     o->shrink = FALSE;
     o->dir = OB_DIRECTION_WEST;
     o->once = FALSE;
-
-    xmlNodePtr n;
-    if ((n = obt_xml_find_node(node, "once")))
-        o->once = obt_xml_node_bool(n);
 
     return o;
 }

--- a/openbox/actions/growtoedge.c
+++ b/openbox/actions/growtoedge.c
@@ -91,28 +91,6 @@ static gpointer setup_fill_func(xmlNodePtr node)
     return o;
 }
 
-static gpointer setup_grow_func(xmlNodePtr node)
-{
-    Options *o;
-
-    o = setup_func(node);
-    o->shrink = FALSE;
-    o->fill = FALSE;
-
-    return o;
-}
-
-static gpointer setup_fill_func(xmlNodePtr node)
-{
-    Options *o;
-
-    o = setup_func(node);
-    o->shrink = FALSE;
-    o->fill = TRUE;
-
-    return o;
-}
-
 static gpointer setup_shrink_func(xmlNodePtr node)
 {
     Options *o;

--- a/openbox/actions/growtoedge.c
+++ b/openbox/actions/growtoedge.c
@@ -10,6 +10,7 @@ typedef struct {
     gboolean shrink;
     gboolean fill;
     gboolean once;
+    gboolean strict;
 } Options;
 
 static gpointer setup_grow_func(xmlNodePtr node);
@@ -65,6 +66,9 @@ static gpointer setup_func(xmlNodePtr node)
 
     if ((n = obt_xml_find_node(node, "once")))
         o->once = obt_xml_node_bool(n);
+
+    if ((n = obt_xml_find_node(node, "strict")))
+        o->strict = obt_xml_node_bool(n);
 
     return o;
 }
@@ -236,7 +240,11 @@ static gboolean run_func(ObActionsData *data, gpointer options)
             return FALSE;
     }
 
-    /* We couldn't grow, so try shrink! */
+    /* We couldn't grow, so try shrink!
+       Except when on script mode. */
+    if (o->strict)
+        return FALSE;
+
     ObDirection opposite =
         (o->dir == OB_DIRECTION_NORTH ? OB_DIRECTION_SOUTH :
          (o->dir == OB_DIRECTION_SOUTH ? OB_DIRECTION_NORTH :

--- a/openbox/actions/growtoedge.c
+++ b/openbox/actions/growtoedge.c
@@ -9,6 +9,7 @@ typedef struct {
     ObDirection dir;
     gboolean shrink;
     gboolean fill;
+    gboolean once;
 } Options;
 
 static gpointer setup_grow_func(xmlNodePtr node);
@@ -69,9 +70,14 @@ static gpointer setup_grow_func(xmlNodePtr node)
 {
     Options *o;
 
+    xmlNodePtr n;
+
     o = setup_func(node);
     o->shrink = FALSE;
     o->fill = FALSE;
+
+    if ((n = obt_xml_find_node(node, "once")))
+        o->once = obt_xml_node_bool(n);
 
     return o;
 }
@@ -80,9 +86,15 @@ static gpointer setup_fill_func(xmlNodePtr node)
 {
     Options *o;
 
+    xmlNodePtr n;
+
     o = setup_func(node);
     o->shrink = FALSE;
     o->fill = TRUE;
+    o->once = FALSE;
+
+    if ((n = obt_xml_find_node(node, "once")))
+        o->once = obt_xml_node_bool(n);
 
     return o;
 }
@@ -91,9 +103,15 @@ static gpointer setup_shrink_func(xmlNodePtr node)
 {
     Options *o;
 
+    xmlNodePtr n;
+
     o = setup_func(node);
     o->shrink = TRUE;
     o->fill = FALSE;
+    o->once = FALSE;
+
+    if ((n = obt_xml_find_node(node, "once")))
+        o->once = obt_xml_node_bool(n);
 
     return o;
 }
@@ -207,7 +225,10 @@ static gboolean run_func(ObActionsData *data, gpointer options)
 
         /* If all the edges are blocked, then allow them to jump past their
            current block points. */
-        do_grow_all_edges(data, CLIENT_RESIZE_GROW);
+        if (!o->once) {
+            do_grow_all_edges(data, CLIENT_RESIZE_GROW);
+        } 
+
         return FALSE;
     }
 
@@ -215,10 +236,17 @@ static gboolean run_func(ObActionsData *data, gpointer options)
         gint x, y, w, h;
 
         /* Try grow. */
-        client_find_resize_directional(data->client,
+        if (o->once) {
+            client_find_resize_directional(data->client,
+                                       o->dir,
+                                       CLIENT_RESIZE_GROW_IF_NOT_ON_EDGE,
+                                       &x, &y, &w, &h);
+        } else {
+            client_find_resize_directional(data->client,
                                        o->dir,
                                        CLIENT_RESIZE_GROW,
                                        &x, &y, &w, &h);
+        }
 
         if (do_grow(data, x, y, w, h))
             return FALSE;
@@ -278,6 +306,12 @@ static gpointer setup_north_func(xmlNodePtr node)
     Options *o = g_slice_new0(Options);
     o->shrink = FALSE;
     o->dir = OB_DIRECTION_NORTH;
+    o->once = FALSE;
+
+    xmlNodePtr n;
+    if ((n = obt_xml_find_node(node, "once")))
+        o->once = obt_xml_node_bool(n);
+
     return o;
 }
 
@@ -286,6 +320,12 @@ static gpointer setup_south_func(xmlNodePtr node)
     Options *o = g_slice_new0(Options);
     o->shrink = FALSE;
     o->dir = OB_DIRECTION_SOUTH;
+    o->once = FALSE;
+
+    xmlNodePtr n;
+    if ((n = obt_xml_find_node(node, "once")))
+        o->once = obt_xml_node_bool(n);
+
     return o;
 }
 
@@ -294,6 +334,12 @@ static gpointer setup_east_func(xmlNodePtr node)
     Options *o = g_slice_new0(Options);
     o->shrink = FALSE;
     o->dir = OB_DIRECTION_EAST;
+    o->once = FALSE;
+
+    xmlNodePtr n;
+    if ((n = obt_xml_find_node(node, "once")))
+        o->once = obt_xml_node_bool(n);
+
     return o;
 }
 
@@ -302,5 +348,11 @@ static gpointer setup_west_func(xmlNodePtr node)
     Options *o = g_slice_new0(Options);
     o->shrink = FALSE;
     o->dir = OB_DIRECTION_WEST;
+    o->once = FALSE;
+
+    xmlNodePtr n;
+    if ((n = obt_xml_find_node(node, "once")))
+        o->once = obt_xml_node_bool(n);
+
     return o;
 }

--- a/openbox/actions/growtoedge.c
+++ b/openbox/actions/growtoedge.c
@@ -8,6 +8,7 @@
 typedef struct {
     ObDirection dir;
     gboolean shrink;
+    gboolean fill;
 } Options;
 
 static gpointer setup_func(xmlNodePtr node);
@@ -19,6 +20,7 @@ static gpointer setup_north_func(xmlNodePtr node);
 static gpointer setup_south_func(xmlNodePtr node);
 static gpointer setup_east_func(xmlNodePtr node);
 static gpointer setup_west_func(xmlNodePtr node);
+static gpointer setup_fill_func(xmlNodePtr node);
 
 void action_growtoedge_startup(void)
 {
@@ -31,6 +33,7 @@ void action_growtoedge_startup(void)
     actions_register("GrowToEdgeSouth", setup_south_func, free_func, run_func);
     actions_register("GrowToEdgeEast", setup_east_func, free_func, run_func);
     actions_register("GrowToEdgeWest", setup_west_func, free_func, run_func);
+    actions_register("GrowToFill", setup_fill_func, free_func, run_func);
 }
 
 static gpointer setup_func(xmlNodePtr node)
@@ -41,6 +44,7 @@ static gpointer setup_func(xmlNodePtr node)
     o = g_slice_new0(Options);
     o->dir = OB_DIRECTION_NORTH;
     o->shrink = FALSE;
+    o->fill = FALSE;
 
     if ((n = obt_xml_find_node(node, "direction"))) {
         gchar *s = obt_xml_node_string(n);
@@ -61,6 +65,17 @@ static gpointer setup_func(xmlNodePtr node)
 
     return o;
 }
+
+static gpointer setup_fill_func(xmlNodePtr node)
+{
+    Options *o;
+
+    o = setup_func(node);
+    o->fill = TRUE;
+
+    return o;
+}
+
 
 static gpointer setup_shrink_func(xmlNodePtr node)
 {
@@ -107,26 +122,107 @@ static gboolean run_func(ObActionsData *data, gpointer options)
 {
     Options *o = options;
     gint x, y, w, h;
+
     ObDirection opp;
     gint half;
 
-    if (!data->client ||
-        /* don't allow vertical resize if shaded */
-        ((o->dir == OB_DIRECTION_NORTH || o->dir == OB_DIRECTION_SOUTH) &&
-         data->client->shaded))
-    {
+    if (!data->client)
+        return FALSE;
+    if (data->client->shaded) {
+        gboolean doing_verical_resize =
+            o->dir == OB_DIRECTION_NORTH ||
+            o->dir == OB_DIRECTION_SOUTH ||
+            o->fill;
+        if (doing_verical_resize)
+            return FALSE;
+    }
+
+    if (o->fill) {
+        if (o->shrink) {
+            /* We don't have any implementation of shrinking for the FillToGrow
+               action. */
+            return FALSE;
+        }
+
+        gint head, size;
+        gint e_start, e_size;
+        gboolean near;
+
+        gint north_edge;
+        head = RECT_TOP(data->client->frame->area)+1;
+        size = data->client->frame->area.height;
+        e_start = RECT_LEFT(data->client->frame->area);
+        e_size = data->client->frame->area.width;
+
+        client_find_edge_directional(data->client, OB_DIRECTION_NORTH,
+                                     head, size, e_start, e_size,
+                                     &north_edge, &near);
+
+        gint south_edge;
+        head = RECT_BOTTOM(data->client->frame->area)-1;
+        size = data->client->frame->area.height;
+        e_start = RECT_LEFT(data->client->frame->area);
+        e_size = data->client->frame->area.width;
+
+        client_find_edge_directional(data->client, OB_DIRECTION_SOUTH,
+                                     head, size, e_start, e_size,
+                                     &south_edge, &near);
+
+        gint east_edge;
+        head = RECT_RIGHT(data->client->frame->area)-1;
+        size = data->client->frame->area.width;
+        e_start = RECT_TOP(data->client->frame->area);
+        e_size = data->client->frame->area.height;
+
+        client_find_edge_directional(data->client, OB_DIRECTION_EAST,
+                                     head, size, e_start, e_size,
+                                     &east_edge, &near);
+
+        gint west_edge;
+        head = RECT_LEFT(data->client->frame->area)+1;
+        size = data->client->frame->area.width;
+        e_start = RECT_TOP(data->client->frame->area);
+        e_size = data->client->frame->area.height;
+
+        client_find_edge_directional(data->client, OB_DIRECTION_WEST,
+                                     head, size, e_start, e_size,
+                                     &west_edge, &near);
+
+        /* Calculate the client pos and size, based on frame pos and size.
+         */
+
+        gint w_client_delta =
+            data->client->frame->area.width - data->client->area.width;
+        gint h_client_delta =
+            data->client->frame->area.height - data->client->area.height;
+
+        gint x_client_delta =
+            data->client->area.x - data->client->frame->area.x;
+        gint y_client_delta =
+            data->client->area.y - data->client->frame->area.y;
+
+        x = west_edge + x_client_delta + 1;
+        y = north_edge + y_client_delta + 1;
+
+        w = east_edge - west_edge - w_client_delta - 1;
+        h = south_edge - north_edge - h_client_delta - 1;
+
+        /* grow passing client pos and size */
+
+        do_grow(data, x, y, w, h);
         return FALSE;
     }
 
     if (!o->shrink) {
-        /* try grow */
+        /* Try grow. */
         client_find_resize_directional(data->client, o->dir, TRUE,
                                        &x, &y, &w, &h);
+
         if (do_grow(data, x, y, w, h))
             return FALSE;
     }
 
-    /* we couldn't grow, so try shrink! */
+    /* We couldn't grow, so try shrink! */
     opp = (o->dir == OB_DIRECTION_NORTH ? OB_DIRECTION_SOUTH :
            (o->dir == OB_DIRECTION_SOUTH ? OB_DIRECTION_NORTH :
             (o->dir == OB_DIRECTION_EAST ? OB_DIRECTION_WEST :

--- a/openbox/actions/movetoedge.c
+++ b/openbox/actions/movetoedge.c
@@ -7,6 +7,7 @@
 
 typedef struct {
     ObDirection dir;
+    gboolean once;
 } Options;
 
 static gpointer setup_func(xmlNodePtr node);
@@ -53,6 +54,9 @@ static gpointer setup_func(xmlNodePtr node)
         g_free(s);
     }
 
+    if ((n = obt_xml_find_node(node, "once")))
+        o->once = obt_xml_node_bool(n);
+
     return o;
 }
 
@@ -69,7 +73,11 @@ static gboolean run_func(ObActionsData *data, gpointer options)
     if (data->client) {
         gint x, y;
 
-        client_find_move_directional(data->client, o->dir, &x, &y);
+        if (o->once)
+            client_find_move_directional(data->client, o->dir, CLIENT_MOVE_MOVE_IF_NOT_ON_EDGE, &x, &y);
+        else
+            client_find_move_directional(data->client, o->dir, CLIENT_MOVE_MOVE, &x, &y);
+
         if (x != data->client->area.x || y != data->client->area.y) {
             actions_client_move(data, TRUE);
             client_move(data->client, x, y);

--- a/openbox/client.c
+++ b/openbox/client.c
@@ -4468,7 +4468,7 @@ void client_find_edge_directional(ObClient *self, ObDirection dir,
     g_slice_free(Rect, a);
 }
 
-void client_find_move_directional(ObClient *self, ObDirection dir,
+void client_find_move_directional(ObClient *self, ObDirection dir,  ObClientDirectionalMoveType move_type,
                                   gint *x, gint *y)
 {
     gint head, size;
@@ -4478,24 +4478,52 @@ void client_find_move_directional(ObClient *self, ObDirection dir,
     switch (dir) {
     case OB_DIRECTION_EAST:
         head = RECT_RIGHT(self->frame->area);
+        switch (move_type) {
+        case CLIENT_MOVE_MOVE_IF_NOT_ON_EDGE:
+            head -= 1;
+            break;
+        case CLIENT_MOVE_MOVE:
+            break;
+        }
         size = self->frame->area.width;
         e_start = RECT_TOP(self->frame->area);
         e_size = self->frame->area.height;
         break;
     case OB_DIRECTION_WEST:
         head = RECT_LEFT(self->frame->area);
+        switch (move_type) {
+        case CLIENT_MOVE_MOVE_IF_NOT_ON_EDGE:
+            head += 1;
+            break;
+        case CLIENT_MOVE_MOVE:
+            break;
+        }
         size = self->frame->area.width;
         e_start = RECT_TOP(self->frame->area);
         e_size = self->frame->area.height;
         break;
     case OB_DIRECTION_NORTH:
         head = RECT_TOP(self->frame->area);
+        switch (move_type) {
+        case CLIENT_MOVE_MOVE_IF_NOT_ON_EDGE:
+            head += 1;
+            break;
+        case CLIENT_MOVE_MOVE:
+            break;
+        }
         size = self->frame->area.height;
         e_start = RECT_LEFT(self->frame->area);
         e_size = self->frame->area.width;
         break;
     case OB_DIRECTION_SOUTH:
         head = RECT_BOTTOM(self->frame->area);
+        switch (move_type) {
+        case CLIENT_MOVE_MOVE_IF_NOT_ON_EDGE:
+            head -= 1;
+            break;
+        case CLIENT_MOVE_MOVE:
+            break;
+        }
         size = self->frame->area.height;
         e_start = RECT_LEFT(self->frame->area);
         e_size = self->frame->area.width;
@@ -4506,6 +4534,7 @@ void client_find_move_directional(ObClient *self, ObDirection dir,
 
     client_find_edge_directional(self, dir, head, size,
                                  e_start, e_size, &e, &near);
+
     *x = self->frame->area.x;
     *y = self->frame->area.y;
     switch (dir) {

--- a/openbox/client.c
+++ b/openbox/client.c
@@ -4535,18 +4535,15 @@ void client_find_move_directional(ObClient *self, ObDirection dir,
     frame_frame_gravity(self->frame, x, y);
 }
 
-gboolean client_find_resize_directional(
-    ObClient *self,
-    ObDirection side,
-    ObClientDirectionalResizeType resize_type,
-    gint *x, gint *y, gint *w, gint *h)
+void client_find_resize_directional(ObClient *self,
+                                    ObDirection side,
+                                    ObClientDirectionalResizeType resize_type,
+                                    gint *x, gint *y, gint *w, gint *h)
 {
     gint head;
     gint e, e_start, e_size, delta;
     gboolean near;
     ObDirection dir;
-
-    gboolean changed = FALSE;
 
     gboolean grow;
     switch (resize_type) {
@@ -4647,27 +4644,23 @@ gboolean client_find_resize_directional(
         if (grow == near) --e;
         delta = e - RECT_RIGHT(self->frame->area);
         *w += delta;
-        changed = delta ? TRUE : changed;
         break;
     case OB_DIRECTION_WEST:
         if (grow == near) ++e;
         delta = RECT_LEFT(self->frame->area) - e;
         *x -= delta;
         *w += delta;
-        changed = delta ? TRUE : changed;
         break;
     case OB_DIRECTION_NORTH:
         if (grow == near) ++e;
         delta = RECT_TOP(self->frame->area) - e;
         *y -= delta;
         *h += delta;
-        changed = delta ? TRUE : changed;
         break;
     case OB_DIRECTION_SOUTH:
         if (grow == near) --e;
         delta = e - RECT_BOTTOM(self->frame->area);
         *h += delta;
-        changed = delta ? TRUE : changed;
        break;
     default:
         g_assert_not_reached();
@@ -4675,7 +4668,6 @@ gboolean client_find_resize_directional(
     frame_frame_gravity(self->frame, x, y);
     *w -= self->frame->size.left + self->frame->size.right;
     *h -= self->frame->size.top + self->frame->size.bottom;
-    return changed;
 }
 
 ObClient* client_under_pointer(void)

--- a/openbox/client.h
+++ b/openbox/client.h
@@ -496,14 +496,11 @@ typedef enum {
     CLIENT_RESIZE_SHRINK,
 } ObClientDirectionalResizeType;
 
-/*! Moves the client area passed in to grow/shrink the given edge.
-  @return TRUE if any change was made to the client area.
-*/
-gboolean client_find_resize_directional(
-    ObClient *self,
-    ObDirection side,
-    ObClientDirectionalResizeType resize_type,
-    gint *x, gint *y, gint *w, gint *h);
+/*! Moves the client area passed in to grow/shrink the given edge. */
+void client_find_resize_directional(ObClient *self,
+                                    ObDirection side,
+                                    ObClientDirectionalResizeType resize_type,
+                                    gint *x, gint *y, gint *w, gint *h);
 
 /*! Fullscreen's or unfullscreen's the client window
   @param fs true if the window should be made fullscreen; false if it should

--- a/openbox/client.h
+++ b/openbox/client.h
@@ -489,9 +489,21 @@ void client_find_edge_directional(ObClient *self, ObDirection dir,
                                   gint *dest, gboolean *near_edge);
 void client_find_move_directional(ObClient *self, ObDirection dir,
                                   gint *x, gint *y);
-void client_find_resize_directional(ObClient *self, ObDirection side,
-                                    gboolean grow,
-                                    gint *x, gint *y, gint *w, gint *h);
+
+typedef enum {
+    CLIENT_RESIZE_GROW,
+    CLIENT_RESIZE_GROW_IF_NOT_ON_EDGE,
+    CLIENT_RESIZE_SHRINK,
+} ObClientDirectionalResizeType;
+
+/*! Moves the client area passed in to grow/shrink the given edge.
+  @return TRUE if any change was made to the client area.
+*/
+gboolean client_find_resize_directional(
+    ObClient *self,
+    ObDirection side,
+    ObClientDirectionalResizeType resize_type,
+    gint *x, gint *y, gint *w, gint *h);
 
 /*! Fullscreen's or unfullscreen's the client window
   @param fs true if the window should be made fullscreen; false if it should

--- a/openbox/client.h
+++ b/openbox/client.h
@@ -487,7 +487,13 @@ void client_find_edge_directional(ObClient *self, ObDirection dir,
                                   gint my_head, gint my_tail,
                                   gint my_edge_start, gint my_edge_size,
                                   gint *dest, gboolean *near_edge);
-void client_find_move_directional(ObClient *self, ObDirection dir,
+
+typedef enum {
+    CLIENT_MOVE_MOVE,
+    CLIENT_MOVE_MOVE_IF_NOT_ON_EDGE,
+} ObClientDirectionalMoveType;
+
+void client_find_move_directional(ObClient *self, ObDirection dir, ObClientDirectionalMoveType move_type,
                                   gint *x, gint *y);
 
 typedef enum {

--- a/openbox/moveresize.c
+++ b/openbox/moveresize.c
@@ -694,7 +694,7 @@ static void move_with_keys(KeySym sym, guint state)
         else /* sym == XK_Up */
             dir = OB_DIRECTION_NORTH;
 
-        client_find_move_directional(moveresize_client, dir, &x, &y);
+        client_find_move_directional(moveresize_client, dir, CLIENT_MOVE_MOVE, &x, &y);
         dx = x - moveresize_client->area.x;
         dy = y - moveresize_client->area.y;
     } else {

--- a/openbox/moveresize.c
+++ b/openbox/moveresize.c
@@ -795,8 +795,13 @@ static void resize_with_keys(KeySym sym, guint state)
         else /* if (sym == XK_Up)) */
             dir = OB_DIRECTION_NORTH;
 
-        client_find_resize_directional(moveresize_client, key_resize_edge,
-                                       key_resize_edge == dir,
+        ObClientDirectionalResizeType resize_type =
+            key_resize_edge == dir ? CLIENT_RESIZE_GROW
+                                   : CLIENT_RESIZE_SHRINK;
+
+        client_find_resize_directional(moveresize_client,
+                                       key_resize_edge,
+                                       resize_type,
                                        &x, &y, &w, &h);
         dw = w - moveresize_client->area.width;
         dh = h - moveresize_client->area.height;

--- a/openbox/place_overlap.c
+++ b/openbox/place_overlap.c
@@ -171,11 +171,6 @@ static int total_overlap(const Rect* client_rects,
     return overlap;
 }
 
-/* Unfortunately, the libc bsearch() function cannot be used to find the
-   position of a value that is not in the array, and glib doesn't
-   provide a binary search function at all.  So, tricky as it is, if we
-   want to avoid linear scan of the edge array, we have to roll our
-   own. */
 static int find_first_grid_position_greater_or_equal(int search_value,
                                                      const int* edges,
                                                      int max_edges)


### PR DESCRIPTION
Just noticed... github updates automatically my pull request to the latest revision... 

I'm proposing this 2 new options:

1) "once": will restrict GrowTo_/MoveTo_ to the nearest blocking edges.

2) "strict": forces GrowTo\* actions to do strictly what they name says: grow. So, this option will prevent GrowTo from shrinking. 

The name "strict" is just a suggestion, I tryed to think in a generic name who could be applied to any other methods who have "controversal" behaviours. The "strict" was implemented only on GrowTo\* actions.

More info & Usage:
https://bugzilla.icculus.org/show_bug.cgi?id=3356#c38
