### PR TITLE
Disable desktop icons, code to acquire events #111

### DIFF
--- a/README-kanux.mkd
+++ b/README-kanux.mkd
@@ -1,0 +1,19 @@
+##Openbox 3.5.2 for KanuxOS
+
+This fork is used in Kanux to fix:
+
+ * Fix the hourglass mouse cursor - originally fixed by openbox project
+ * Disable desktop icons when starting an application.
+
+###Debugging openbox
+
+Debug events are emitted with the prefix ">>>" to dissipate original openbox messages.
+To test functionality manually, with LXDE running:
+
+ * pkill openbox
+
+Taskbar, desktop icons and window frames should visually disappear.
+
+ 2. openbox --debug
+
+User interaction event messages are emitted to the console.

--- a/openbox/client.c
+++ b/openbox/client.c
@@ -71,6 +71,13 @@ typedef struct
 
 GList          *client_list             = NULL;
 
+
+// Albert - Boolean variable to tell us if we need to 
+// disable the desktop icons as input events start to be dispatched.
+// see startupnotify.c
+extern gboolean bDisableDesktop;
+
+
 static GSList  *client_destroy_notifies = NULL;
 static RrImage *client_default_icon     = NULL;
 
@@ -890,6 +897,15 @@ static gboolean client_can_steal_focus(ObClient *self,
                          "another desktop and no relatives are focused ");
             }
         }
+    }
+
+
+    // Albert - At this point we can decide wether a graphic object
+    // is allowed to acquire focus. Are we starting an app
+    // and the mouse hourglass is active?
+
+    if (bDisableDesktop == TRUE) {
+        ob_debug(">>> Mouse hourglass is active - DISABLING DESKTOP ICONS");
     }
 
     if (!steal)


### PR DESCRIPTION
There are 2 main improvements in the original openbox code:
- when the mouse pointer changes to hourglass we keep a global flag.
- when openbox needs to decide wether focus can change, we know if the hourglass is active.

This change does not actually disable desktop icons yet.
