### PR TITLE
Add keybindings for window tiling

### DIFF
--- a/data/rc.xml
+++ b/data/rc.xml
@@ -298,6 +298,44 @@
     </action>
   </keybind>
 
+  <!-- Keybindings for window tiling -->
+  <keybind key="W-Left">        # HalfLeftScreen
+    <action name="UnmaximizeFull"/>
+    <action name="MoveResizeTo">
+      <x>0</x>
+      <y>0</y>
+      <height>100%</height>
+      <width>50%</width>
+    </action>
+  </keybind>
+  <keybind key="W-Right">       # HalfRightScreen
+    <action name="UnmaximizeFull"/>
+    <action name="MoveResizeTo">
+      <x>-0</x>
+      <y>0</y>
+      <height>100%</height>
+      <width>50%</width>
+    </action>
+  </keybind>
+  <keybind key="W-Up">          # HalfUpperScreen
+    <action name="UnmaximizeFull"/>
+    <action name="MoveResizeTo">
+      <x>0</x>
+      <y>0</y>
+      <width>100%</width>
+      <height>50%</height>
+    </action>
+  </keybind>
+  <keybind key="W-Down">        # HalfLowerScreen
+    <action name="UnmaximizeFull"/>
+    <action name="MoveResizeTo">
+      <x>0</x>
+      <y>-0</y>
+      <width>100%</width>
+      <height>50%</height>
+    </action>
+  </keybind>
+
   <!-- Keybindings for running applications -->
   <keybind key="W-e">
     <action name="Execute">


### PR DESCRIPTION
These keybindings were written by Julien Lavergne gilir@ubuntu.com
and included in the GPL lubuntu-default-settings Ubuntu package. The
only contributions of mine are cleaning up the whitespace and changing
<height>97%</height> to <height>100%</height>.

I intend to get these keybindings into LXDE (see [1] and [2]) but I wanted to give the Openbox developers an opportunity to include them upstream.

[1] https://sourceforge.net/p/lxde/feature-requests/191/#5372
[2] http://git.lxde.org/gitweb/?p=lxde/lxde-common.git;a=blob;f=openbox/rc.xml.in;h=8db93bfee711da94a37ca78088093f6858f8a8ca;hb=HEAD
