### PR TITLE
Add fullscreen query

### DIFF
--- a/openbox/actions/if.c
+++ b/openbox/actions/if.c
@@ -66,6 +66,8 @@ typedef struct {
     gboolean decor_on;
     gboolean omnipresent_on;
     gboolean omnipresent_off;
+    gboolean fullscreen_on;
+    gboolean fullscreen_off;
     gboolean desktop_current;
     gboolean desktop_other;
     guint    desktop_number;
@@ -185,6 +187,7 @@ static void setup_query(Options* o, xmlNodePtr node, QueryTarget target) {
     set_bool(node, "urgent", &q->urgent_on, &q->urgent_off);
     set_bool(node, "undecorated", &q->decor_off, &q->decor_on);
     set_bool(node, "omnipresent", &q->omnipresent_on, &q->omnipresent_off);
+    set_bool(node, "fullscreen", &q->fullscreen_on, &q->fullscreen_off);
 
     xmlNodePtr n;
     if ((n = obt_xml_find_node(node, "desktop"))) {
@@ -384,6 +387,11 @@ static gboolean run_func_if(ObActionsData *data, gpointer options)
             is_true &= query_target->desktop == DESKTOP_ALL;
         if (q->omnipresent_off)
             is_true &= query_target->desktop != DESKTOP_ALL;
+
+        if (q->fullscreen_on)
+            is_true &= query_target->fullscreen;
+        if (q->fullscreen_off)
+            is_true &= !query_target->fullscreen;
 
         gboolean is_on_current_desktop =
             query_target->desktop == screen_desktop ||


### PR DESCRIPTION
See feature request https://bugzilla.icculus.org/show_bug.cgi?id=6380
This adds the ability to query a window in the If and ForEach actions to determine if it is fullscreen or not. It also allows the user to make a window not fullscreen no matter the state before like the example in the feature request, or make a window fullscreen no matter the state before.
