### PR TITLE
Fullscreen on/off actions

### DIFF
--- a/openbox/actions/fullscreen.c
+++ b/openbox/actions/fullscreen.c
@@ -6,6 +6,8 @@ static gboolean run_func_toggle(ObActionsData *data, gpointer options);
 void action_fullscreen_startup(void)
 {
     actions_register("ToggleFullscreen", NULL, NULL, run_func_toggle);
+    actions_register("Fullscreen", NULL, NULL, run_func_on);
+    actions_register("Unfullscreen", NULL, NULL, run_func_off);
 }
 
 /* Always return FALSE because its not interactive */
@@ -14,6 +16,28 @@ static gboolean run_func_toggle(ObActionsData *data, gpointer options)
     if (data->client) {
         actions_client_move(data, TRUE);
         client_fullscreen(data->client, !data->client->fullscreen);
+        actions_client_move(data, FALSE);
+    }
+    return FALSE;
+}
+
+/* Always return FALSE because its not interactive */
+static gboolean run_func_on(ObActionsData *data, gpointer options)
+{
+    if (data->client) {
+        actions_client_move(data, TRUE);
+        client_fullscreen(data->client, TRUE);
+        actions_client_move(data, FALSE);
+    }
+    return FALSE;
+}
+
+/* Always return FALSE because its not interactive */
+static gboolean run_func_off(ObActionsData *data, gpointer options)
+{
+    if (data->client) {
+        actions_client_move(data, TRUE);
+        client_fullscreen(data->client, FALSE);
         actions_client_move(data, FALSE);
     }
     return FALSE;


### PR DESCRIPTION
Hi! 

I've added two specific functions for turning fullscreen on an off. It's useful when you are writing an action which needs to make sure that the window is not fullscreen. You can't achieve that with just toggle, because you can't query fullscreenness status. 



