### PR TITLE
Fix out-of-bounds read

### DIFF
--- a/openbox/frame.c
+++ b/openbox/frame.c
@@ -1215,7 +1215,7 @@ static void layout_title(ObFrame *self)
         }
 
         /* stop at the end of the string (or the label, which calls break) */
-        for (; *lc != '\0' && lc >= config_title_layout; lc+=i) {
+        for (; lc >= config_title_layout && *lc != '\0'; lc+=i) {
             if (*lc == 'L') {
                 if (i > 0) {
                     self->label_on = TRUE;


### PR DESCRIPTION
When the direction is right-to-left, `i == -1` so memory is read one byte before the string before the pointer is checked against the bound.