### PR TITLE
Not a pull request: Icons messing up in lxpanel because of openbox

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -282,6 +282,8 @@ openbox_openbox_SOURCES = \
 	openbox/mwm.h \
 	openbox/openbox.c \
 	openbox/openbox.h \
+	openbox/overlap.c \
+	openbox/overlap.h \
 	openbox/ping.c \
 	openbox/ping.h \
 	openbox/place.c \

--- a/data/rc.xsd
+++ b/data/rc.xsd
@@ -511,6 +511,7 @@
         <xsd:restriction base="xsd:string">
             <xsd:enumeration value="Smart"/>
             <xsd:enumeration value="UnderMouse"/>
+            <xsd:enumeration value="LeastOverlap"/>
         </xsd:restriction>
     </xsd:simpleType>
     <xsd:simpleType name="placementmonitor">

--- a/openbox/config.c
+++ b/openbox/config.c
@@ -26,6 +26,7 @@
 #include "screen.h"
 #include "openbox.h"
 #include "gettext.h"
+#include "place.h"
 #include "obt/paths.h"
 
 gboolean config_focus_new;
@@ -581,9 +582,13 @@ static void parse_placement(xmlNodePtr node, gpointer d)
 
     node = node->children;
 
-    if ((n = obt_xml_find_node(node, "policy")))
+    if ((n = obt_xml_find_node(node, "policy"))) {
         if (obt_xml_node_contains(n, "UnderMouse"))
             config_place_policy = OB_PLACE_POLICY_MOUSE;
+        else if (obt_xml_node_contains(n, "LeastOverlap"))
+            config_place_policy = OB_PLACE_POLICY_LEASTOVERLAP;
+
+    }
     if ((n = obt_xml_find_node(node, "center")))
         config_place_center = obt_xml_node_bool(n);
     if ((n = obt_xml_find_node(node, "monitor"))) {

--- a/openbox/config.c
+++ b/openbox/config.c
@@ -26,7 +26,6 @@
 #include "screen.h"
 #include "openbox.h"
 #include "gettext.h"
-#include "place.h"
 #include "obt/paths.h"
 
 gboolean config_focus_new;

--- a/openbox/geom.h
+++ b/openbox/geom.h
@@ -102,6 +102,10 @@ typedef struct _Rect {
      (r).height = MIN((a).y + (a).height - 1, \
                       (b).y + (b).height - 1) - (r).y + 1)
 
+/* Returns the 2-dimensional area of Rect r */
+#define RECT_AREA(r) \
+    (((r).width) * ((r).height))
+
 typedef struct _Strut {
     int left;
     int top;

--- a/openbox/overlap.c
+++ b/openbox/overlap.c
@@ -1,0 +1,175 @@
+/* -*- indent-tabs-mode: nil; tab-width: 4; c-basic-offset: 4; -*-
+
+   overlap.c for the Openbox window manager
+   Copyright (c) 2011        Ian Zimmerman
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   See the COPYING file for a copy of the GNU General Public License.
+*/
+
+#include "config.h"
+#include "geom.h"
+#include "overlap.h"
+
+#include <stdlib.h>
+
+static void
+make_grid(const Rect* client_rects, int n_client_rects, const Rect* bound,
+          int* x_edges, int* y_edges, int max_edges);
+
+static int
+best_direction(const Point* grid_point,
+               const Rect* client_rects, int n_client_rects,
+               const Rect* bound, const Size* req_size, Point* best_top_left);
+
+/* Choose the placement on a grid with least overlap */
+
+void
+overlap_find_least_placement(const Rect* client_rects, int n_client_rects,
+                             Rect *const bound,
+                             const Size* req_size, Point* result)
+{
+    result->x = result->y = 0;
+    int overlap = G_MAXINT;
+    int max_edges = 2 * (n_client_rects + 1);
+
+	int x_edges[max_edges];
+	int y_edges[max_edges];
+	make_grid(client_rects, n_client_rects, bound,
+			  x_edges, y_edges, max_edges);
+	int i;
+	for (i = 0; i < max_edges; ++i) {
+		if (x_edges[i] == G_MAXINT)
+			break;
+		int j;
+		for (j = 0; j < max_edges; ++j) {
+			if (y_edges[j] == G_MAXINT)
+				break;
+			Point grid_point = {.x = x_edges[i], .y = y_edges[j]};
+			Point best_top_left;
+			int this_overlap =
+				best_direction(&grid_point, client_rects, n_client_rects,
+							   bound, req_size, &best_top_left);
+			if (this_overlap < overlap) {
+				overlap = this_overlap;
+				*result = best_top_left;
+			}
+			if (overlap == 0)
+				break;
+		}
+		if (overlap == 0)
+			break;
+	}
+}
+
+static int compare_ints(const void* a, const void* b)
+{
+    const int* ia = (const int*)a;
+    const int* ib = (const int*)b;
+    return *ia - *ib;
+}
+
+static void uniquify(int* edges, int n_edges)
+{
+    int i = 0;
+    int j = 0;
+
+    while (j < n_edges) {
+        int last = edges[j++];
+        edges[i++] = last;
+        while (j < n_edges && edges[j] == last)
+            ++j;
+    }
+    /* fill the rest with nonsense */
+    for (; i < n_edges ; ++i)
+        edges[i] = G_MAXINT;
+}
+
+static void
+make_grid(const Rect* client_rects, int n_client_rects, const Rect* bound,
+          int* x_edges, int* y_edges, int max_edges)
+{
+    int i;
+    int n_edges = 0;
+    for (i = 0; i < n_client_rects; ++i) {
+        if (!RECT_INTERSECTS_RECT(client_rects[i], *bound))
+            continue;
+        x_edges[n_edges] = client_rects[i].x;
+        y_edges[n_edges++] = client_rects[i].y;
+        x_edges[n_edges] = client_rects[i].x + client_rects[i].width;
+        y_edges[n_edges++] = client_rects[i].y + client_rects[i].height;
+    }
+    x_edges[n_edges] = bound->x;
+    y_edges[n_edges++] = bound->y;
+    x_edges[n_edges] = bound->x + bound->width;
+    y_edges[n_edges++] = bound->y + bound->height;
+    for (i = n_edges; i < max_edges; ++i)
+        x_edges[i] = y_edges[i] = G_MAXINT;
+    qsort(x_edges, n_edges, sizeof(int), compare_ints);
+    uniquify(x_edges, n_edges);
+    qsort(y_edges, n_edges, sizeof(int), compare_ints);
+    uniquify(y_edges, n_edges);
+}
+
+static int total_overlap(const Rect* client_rects, int n_client_rects,
+                         const Rect* proposed_rect)
+{
+    int overlap = 0;
+    int i;
+    for (i = 0; i < n_client_rects; ++i) {
+        if (!RECT_INTERSECTS_RECT(*proposed_rect, client_rects[i]))
+            continue;
+        Rect rtemp;
+        RECT_SET_INTERSECTION(rtemp, *proposed_rect, client_rects[i]);
+        overlap += RECT_AREA(rtemp);
+    }
+    return overlap;
+}
+
+/* Given a list of Rect RECTS, a Point PT and a Size size, determine the
+ * direction from PT which results in the least total overlap with RECTS
+ * if a rectangle is placed in that direction.  Return the top/left
+ * Point of such rectangle and the resulting overlap amount.  Only
+ * consider placements within BOUNDS. */
+
+#define NUM_DIRECTIONS 4
+
+static int
+best_direction(const Point* grid_point,
+               const Rect* client_rects, int n_client_rects,
+               const Rect* bound, const Size* req_size, Point* best_top_left)
+{
+    static const Size directions[NUM_DIRECTIONS] = {
+        {0, 0}, {0, -1}, {-1, 0}, {-1, -1}
+    };
+    int overlap = G_MAXINT;
+    int i;
+    for (i = 0; i < NUM_DIRECTIONS; ++i) {
+        Point pt = {
+            .x = grid_point->x + (req_size->width * directions[i].width),
+            .y = grid_point->y + (req_size->height * directions[i].height)
+        };
+        Rect r;
+        RECT_SET_POINT(r, pt.x, pt.y);
+        RECT_SET_SIZE(r, req_size->width, req_size->height);
+        if (!RECT_CONTAINS_RECT(*bound, r))
+            continue;
+        int this_overlap = total_overlap(client_rects, n_client_rects, &r);
+        if (this_overlap < overlap) {
+            overlap = this_overlap;
+            *best_top_left = pt;
+        }
+        if (overlap == 0)
+            break;
+    }
+    return overlap;
+}

--- a/openbox/overlap.h
+++ b/openbox/overlap.h
@@ -1,0 +1,24 @@
+/* -*- indent-tabs-mode: nil; tab-width: 4; c-basic-offset: 4; -*-
+
+   overlap.h for the Openbox window manager
+   Copyright (c) 2011        Ian Zimmerman
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   See the COPYING file for a copy of the GNU General Public License.
+*/
+
+#include "geom.h"
+
+void
+overlap_find_least_placement(const Rect* client_rects, int n_client_rects,
+                             Rect *const bounds, const Size* req_size,
+                             Point* result);

--- a/openbox/place.c
+++ b/openbox/place.c
@@ -559,7 +559,7 @@ static gboolean place_transient_splash(ObClient *client, Rect *area,
     return FALSE;
 }
 
-static gboolean place_least_overlap(ObClient *c, gboolean foreground, gint *x, gint *y)
+static gboolean place_least_overlap(ObClient *c, gboolean foreground, gint *x, gint *y, Rect * const head)
 {
     /* assemble the list of "interesting" windows to calculate overlap against */
     GSList* interesting_clients = NULL;
@@ -598,9 +598,6 @@ static gboolean place_least_overlap(ObClient *c, gboolean foreground, gint *x, g
     }
     g_slist_free(interesting_clients);
 
-    /* add the monitor */
-    Rect * const head = pick_head(c, foreground);
-
     Point result;
     Size req_size;
     SIZE_SET(req_size, c->frame->area.width, c->frame->area.height);
@@ -633,8 +630,10 @@ gboolean place_client(ObClient *client, gboolean foreground, gint *x, gint *y,
     /* try a number of methods */
     ret = place_per_app_setting(client, area, x, y, settings) ||
         place_transient_splash(client, area, x, y) ||
-        (config_place_policy == OB_PLACE_POLICY_MOUSE        && place_under_mouse  (client,       x, y)) ||
-        (config_place_policy == OB_PLACE_POLICY_LEASTOVERLAP && place_least_overlap(client, foreground, x, y)) ||
+        (config_place_policy == OB_PLACE_POLICY_MOUSE
+            && place_under_mouse  (client, x, y)) ||
+        (config_place_policy == OB_PLACE_POLICY_LEASTOVERLAP
+            && place_least_overlap(client, foreground, x, y, area)) ||
         place_nooverlap(client, area, x, y) ||
         place_random(client, area, x, y);
     g_assert(ret);

--- a/openbox/place.c
+++ b/openbox/place.c
@@ -559,7 +559,7 @@ static gboolean place_transient_splash(ObClient *client, Rect *area,
     return FALSE;
 }
 
-static gboolean place_least_overlap(ObClient *c, gboolean foreground, gint *x, gint *y, Rect * const head)
+static gboolean place_least_overlap(ObClient *c, gint *x, gint *y, Rect * const head)
 {
     /* assemble the list of "interesting" windows to calculate overlap against */
     GSList* interesting_clients = NULL;
@@ -633,7 +633,7 @@ gboolean place_client(ObClient *client, gboolean foreground, gint *x, gint *y,
         (config_place_policy == OB_PLACE_POLICY_MOUSE
             && place_under_mouse  (client, x, y)) ||
         (config_place_policy == OB_PLACE_POLICY_LEASTOVERLAP
-            && place_least_overlap(client, foreground, x, y, area)) ||
+            && place_least_overlap(client, x, y, area)) ||
         place_nooverlap(client, area, x, y) ||
         place_random(client, area, x, y);
     g_assert(ret);

--- a/openbox/place.h
+++ b/openbox/place.h
@@ -28,7 +28,8 @@ struct _ObAppSettings;
 typedef enum
 {
     OB_PLACE_POLICY_SMART,
-    OB_PLACE_POLICY_MOUSE
+    OB_PLACE_POLICY_MOUSE,
+    OB_PLACE_POLICY_LEASTOVERLAP,
 } ObPlacePolicy;
 
 typedef enum


### PR DESCRIPTION
Hi, I'm sorry I know this isn't a pull-request but I need to bring this to the attention of someone. On all of my computers I use LXDE with openbox... I thought it was LXDE, but its actually not LXDE, because I tried to use XFCE & when I switched the WM to openbox I noticed all the same icons are getting messed up!
network-manager-applet, blueman, and a few other things(power managers, some other stuff), don't work properly on the lxpanel when openbox is in use, for example with network-manager-applet it does not display the appropriate range, when I click disconnect it shows its still connected on the icon but its not actually still connected. I really hope someone comes upon this & can tell me how this is fixed, because I don't see anyone else saying the same thing and I find that extremely weird since I use LXDE & Openbox on a few different distros, with different icons sets.