### PR TITLE
make focus cycle themeable

### DIFF
--- a/obrender/theme.c
+++ b/obrender/theme.c
@@ -435,6 +435,12 @@ RrTheme* RrThemeNew(const RrInstance *inst, const gchar *name,
     READ_COLOR("osd.button.focused.box.color",
                theme->osd_focused_lineart,
                RrColorCopy(theme->titlebut_focused_hover_color));
+    READ_COLOR("focus.cycle.bg.color",
+               theme->focus_cycle_bg_color,
+               RrColorNew(inst, 0, 0, 0));
+    READ_COLOR("focus.cycle.border.color",
+               theme->focus_cycle_border_color,
+               RrColorNew(inst, 0xFF, 0xFF, 0xFF));
  
     /* load window buttons */
 
@@ -1061,6 +1067,8 @@ void RrThemeFree(RrTheme *theme)
         RrColorFree(theme->osd_focused_lineart);
         RrColorFree(theme->menu_title_shadow_color);
         RrColorFree(theme->menu_text_shadow_color);
+        RrColorFree(theme->focus_cycle_bg_color);
+        RrColorFree(theme->focus_cycle_border_color);
 
         g_free(theme->def_win_icon);
         

--- a/obrender/theme.h
+++ b/obrender/theme.h
@@ -115,6 +115,8 @@ struct _RrTheme {
     RrColor *osd_focused_lineart;
     RrColor *menu_title_shadow_color;
     RrColor *menu_text_shadow_color;
+    RrColor *focus_cycle_bg_color;
+    RrColor *focus_cycle_border_color;
 
     /* style settings - pics */
     RrPixel32 *def_win_icon; /* RGBA */

--- a/openbox/focus_cycle_indicator.c
+++ b/openbox/focus_cycle_indicator.c
@@ -39,7 +39,7 @@ static struct
 } focus_indicator;
 
 static RrAppearance *a_focus_indicator;
-static RrColor      *color_white;
+static RrColor      *border_color;
 static gboolean      visible;
 
 static Window create_window(Window parent, gulong mask,
@@ -92,28 +92,28 @@ void focus_cycle_indicator_startup(gboolean reconfig)
     window_add(&focus_indicator.bottom.window,
                INTERNAL_AS_WINDOW(&focus_indicator.bottom));
 
-    color_white = RrColorNew(ob_rr_inst, 0xff, 0xff, 0xff);
-
     a_focus_indicator = RrAppearanceNew(ob_rr_inst, 4);
     a_focus_indicator->surface.grad = RR_SURFACE_SOLID;
     a_focus_indicator->surface.relief = RR_RELIEF_FLAT;
-    a_focus_indicator->surface.primary = RrColorNew(ob_rr_inst,
-                                                    0, 0, 0);
+    a_focus_indicator->surface.primary = ob_rr_theme->focus_cycle_bg_color;
+
+    border_color = ob_rr_theme->focus_cycle_border_color;
+
     a_focus_indicator->texture[0].type = RR_TEXTURE_LINE_ART;
-    a_focus_indicator->texture[0].data.lineart.color = color_white;
+    a_focus_indicator->texture[0].data.lineart.color = border_color;
     a_focus_indicator->texture[1].type = RR_TEXTURE_LINE_ART;
-    a_focus_indicator->texture[1].data.lineart.color = color_white;
+    a_focus_indicator->texture[1].data.lineart.color = border_color;
     a_focus_indicator->texture[2].type = RR_TEXTURE_LINE_ART;
-    a_focus_indicator->texture[2].data.lineart.color = color_white;
+    a_focus_indicator->texture[2].data.lineart.color = border_color;
     a_focus_indicator->texture[3].type = RR_TEXTURE_LINE_ART;
-    a_focus_indicator->texture[3].data.lineart.color = color_white;
+    a_focus_indicator->texture[3].data.lineart.color = border_color;
 }
 
 void focus_cycle_indicator_shutdown(gboolean reconfig)
 {
     if (reconfig) return;
 
-    RrColorFree(color_white);
+    RrColorFree(border_color);
 
     RrAppearanceFree(a_focus_indicator);
 
@@ -204,6 +204,16 @@ void focus_cycle_draw_indicator(ObClient *c)
 
         XMoveResizeWindow(obt_display, focus_indicator.left.window,
                           x, y, w, h);
+
+        a_focus_indicator->surface.primary = ob_rr_theme->focus_cycle_bg_color;
+
+        border_color = ob_rr_theme->focus_cycle_border_color;
+
+        a_focus_indicator->texture[0].data.lineart.color = border_color;
+        a_focus_indicator->texture[1].data.lineart.color = border_color;
+        a_focus_indicator->texture[2].data.lineart.color = border_color;
+        a_focus_indicator->texture[3].data.lineart.color = border_color;
+
         a_focus_indicator->texture[0].data.lineart.x1 = w-1;
         a_focus_indicator->texture[0].data.lineart.y1 = 0;
         a_focus_indicator->texture[0].data.lineart.x2 = 0;


### PR DESCRIPTION
add new theme elements:
- focus.cycle.bg.color
- focus.cycle.border.color

Explanation:
I was suprised this highly configurable window manager had no option to theme the focus indicator and the default colors did not match my theme.
After finding out that the colors were hard-coded, I decided to make the background and border of the focus indicator themeable.
Just add the above entries to your theme and apply some color values. Good Luck  :-)