### PR TITLE
Enlarged (big) close button by adding 'close.button.percent' parameter to theme

### DIFF
--- a/obrender/theme.c
+++ b/obrender/theme.c
@@ -262,6 +262,7 @@ RrTheme* RrThemeNew(const RrInstance *inst, const gchar *name,
     READ_INT("window.handle.width", theme->handle_height, 0, 100, 6);
     READ_INT("padding.width", theme->paddingx, 0, 100, 3);
     READ_INT("padding.height", theme->paddingy, 0, 100, theme->paddingx);
+    READ_INT("close.button.percent", theme->close_button_percent, 0, 300, 100);
     READ_INT("border.width", theme->fbwidth, 0, 100, 1);
     READ_INT("menu.border.width", theme->mbwidth, 0, 100, theme->fbwidth);
     READ_INT("osd.border.width", theme->obwidth, 0, 100, theme->fbwidth);
@@ -983,6 +984,11 @@ RrTheme* RrThemeNew(const RrInstance *inst, const gchar *name,
             theme->paddingy * 2;
     }
     theme->button_size = theme->label_height - 2;
+    if (theme->close_button_percent>0) {
+        theme->close_button_size = (gint)(theme->button_size * theme->close_button_percent / 100);
+    } else {
+        theme->close_button_size = theme->button_size;
+    }
     theme->grip_width = 25;
 
     RrAppearanceFree(fbs.focused_disabled);

--- a/obrender/theme.h
+++ b/obrender/theme.h
@@ -59,6 +59,8 @@ struct _RrTheme {
     gint label_height;
     gint title_height;
     gint button_size;
+    gint close_button_size;
+    gint close_button_percent;
     gint grip_width;
     gint menu_title_label_height;
     gint menu_title_height;

--- a/openbox/frame.c
+++ b/openbox/frame.c
@@ -207,7 +207,7 @@ static void set_theme_statics(ObFrame *self)
     XResizeWindow(obt_display, self->icon,
                   ob_rr_theme->button_size + 2, ob_rr_theme->button_size + 2);
     XResizeWindow(obt_display, self->close,
-                  ob_rr_theme->button_size, ob_rr_theme->button_size);
+                  ob_rr_theme->close_button_size, ob_rr_theme->button_size);
     XResizeWindow(obt_display, self->desk,
                   ob_rr_theme->button_size, ob_rr_theme->button_size);
     XResizeWindow(obt_display, self->shade,
@@ -1183,6 +1183,7 @@ static void layout_title(ObFrame *self)
     gint i;
 
     const gint bwidth = ob_rr_theme->button_size + ob_rr_theme->paddingx + 1;
+    const gint close_bwidth = ob_rr_theme->close_button_size + ob_rr_theme->paddingx + 1;
     /* position of the leftmost button */
     const gint left = ob_rr_theme->paddingx + 1;
     /* position of the rightmost button */
@@ -1240,7 +1241,7 @@ static void layout_title(ObFrame *self)
                 place_button(self, lc, bwidth, left, i, &x, &self->max_on, &self->max_x);
             } else if (*lc == 'C') {
                 if (firstcon) *firstcon = OB_FRAME_CONTEXT_CLOSE;
-                place_button(self, lc, bwidth, left, i, &x, &self->close_on, &self->close_x);
+                place_button(self, lc, close_bwidth, left, i, &x, &self->close_on, &self->close_x);
             } else
                 continue; /* don't set firstcon */
             firstcon = NULL;

--- a/openbox/framerender.c
+++ b/openbox/framerender.c
@@ -408,5 +408,5 @@ static void framerender_close(ObFrame *self, RrAppearance *a)
 {
     if (!self->close_on) return;
     RrPaint(a, self->close,
-            ob_rr_theme->button_size, ob_rr_theme->button_size);
+            ob_rr_theme->close_button_size, ob_rr_theme->button_size);
 }

--- a/themes/Syscrash/openbox-3/themerc
+++ b/themes/Syscrash/openbox-3/themerc
@@ -10,6 +10,7 @@ padding.width:				1
 window.handle.width:			0
 window.client.padding.width:		0
 window.client.padding.height:		0
+close.button.percent:			150
 
 menu.overlap:				0
 


### PR DESCRIPTION
This is improved Openbox with big (enlarged) close button.
To enlarge close button open theme setup file themerc:
and add a parameter "close.button.percent", for example like this:

`  close.button.percent: 150`

it means 150% from base button size. Title of window will looks like this:

`  [_][u][ x ]`