### PR TITLE
Ensure the window is within the screen even if positioned

### DIFF
--- a/openbox/client.c
+++ b/openbox/client.c
@@ -412,8 +412,7 @@ void client_manage(Window window, ObPrompt *prompt)
                              ob_state() == OB_STATE_RUNNING &&
                              (self->type == OB_CLIENT_TYPE_DIALOG ||
                               self->type == OB_CLIENT_TYPE_SPLASH ||
-                              (!((self->positioned & USPosition) ||
-                                 settings->pos_given) &&
+                              (!settings->pos_given &&
                                client_normal(self) &&
                                !self->session &&
                                /* don't move oldschool fullscreen windows to


### PR DESCRIPTION
Some clients like Qt 6.10 sends a static position to the top left corner, which needs to be moved to fit the window frame to the screen.

See also: https://bugreports.qt.io/browse/QTBUG-141099