### PR TITLE
Handle ToggleShowDesktop for widget-like windows (conky) properly

### DIFF
--- a/openbox/client.c
+++ b/openbox/client.c
@@ -2735,7 +2735,8 @@ gboolean client_should_show(ObClient *self)
     if (self->iconic)
         return FALSE;
     if (client_normal(self) && screen_showing_desktop())
-        return FALSE;
+        if (!(self->skip_taskbar && self->skip_pager && self->below))
+            return FALSE;
     if (self->desktop == screen_desktop || self->desktop == DESKTOP_ALL)
         return TRUE;
 


### PR DESCRIPTION
Adding this small heuristic helps `client_should_show` properly handle widget-like apps (e.g. conky).

I don't think it causes issues with any other applications because in majority of cases `skip_taskbar`, `skip_pager` and `below` are really strong hints the app isn't showing as a normal window. The only thing that comes to mind that breaks this assumption is installer backgrounds that were common around 2010 (in which case hiding the installer too would be a bug), but those are not something we often see on Linux.

Ideally we'd have a `widget` WM_HINT, but that won't be added to X11 at this point lol.

Fixes issue reported in [conky#2304](https://github.com/brndnmtthws/conky/issues/2304).