### PR TITLE
Add perMonitor mode to <margins> for per-monitor gap support

### DIFF
--- a/data/rc.xml
+++ b/data/rc.xml
@@ -162,8 +162,11 @@
 <!-- You can reserve a portion of your screen where windows will not cover when
      they are maximized, or when they are initially placed.
      Many programs reserve space automatically, but you can use this in other
-     cases. -->
-<margins>
+     cases.
+     Set perMonitor="yes" to apply margins per monitor instead of as global
+     struts. In this mode, margins act as gaps inset from each monitor edge
+     and affect maximized windows and MoveToEdge snapping. -->
+<margins perMonitor="no">
   <top>0</top>
   <bottom>0</bottom>
   <left>0</left>

--- a/openbox/actions/moveresizeto.c
+++ b/openbox/actions/moveresizeto.c
@@ -122,7 +122,19 @@ static gboolean run_func(ObActionsData *data, gpointer options)
         }
 
         area = screen_area(c->desktop, mon, NULL);
+        if (config_margins_per_monitor && mon < screen_num_monitors) {
+            area->x     += config_margins.left;
+            area->y     += config_margins.top;
+            area->width  -= config_margins.left + config_margins.right;
+            area->height -= config_margins.top  + config_margins.bottom;
+        }
         carea = screen_area(c->desktop, cmon, NULL);
+        if (config_margins_per_monitor) {
+            carea->x     += config_margins.left;
+            carea->y     += config_margins.top;
+            carea->width  -= config_margins.left + config_margins.right;
+            carea->height -= config_margins.top  + config_margins.bottom;
+        }
 
         /* find a target size for the client/frame. */
         w = o->w;

--- a/openbox/client.c
+++ b/openbox/client.c
@@ -3096,6 +3096,13 @@ void client_try_configure(ObClient *self, gint *x, gint *y, gint *w, gint *h,
         a = screen_area(self->desktop, i,
                         (self->max_horz && self->max_vert ? NULL : &desired));
 
+        if (config_margins_per_monitor) {
+            a->x     += config_margins.left;
+            a->y     += config_margins.top;
+            a->width  -= config_margins.left + config_margins.right;
+            a->height -= config_margins.top  + config_margins.bottom;
+        }
+
         /* set the size and position if maximized */
         if (self->max_horz) {
             *x = a->x;
@@ -4512,6 +4519,12 @@ void client_find_edge_directional(ObClient *self, ObDirection dir,
     /* search for edges of monitors */
     for (i = 0; i < screen_num_monitors; ++i) {
         Rect *area = screen_area(self->desktop, i, NULL);
+        if (config_margins_per_monitor) {
+            area->x     += config_margins.left;
+            area->y     += config_margins.top;
+            area->width  -= config_margins.left + config_margins.right;
+            area->height -= config_margins.top  + config_margins.bottom;
+        }
         detect_edge(*area, dir, my_head, my_size, my_edge_start,
                     my_edge_size, dest, near_edge);
         g_slice_free(Rect, area);

--- a/openbox/client.c
+++ b/openbox/client.c
@@ -4491,21 +4491,21 @@ void client_find_edge_directional(ObClient *self, ObDirection dir,
 
     switch (dir) {
     case OB_DIRECTION_NORTH:
-        edge = RECT_TOP(*a) - 1;
+        edge = RECT_TOP(*a) - 1 + (config_margins_per_monitor ? config_margins.top : 0);
         break;
     case OB_DIRECTION_SOUTH:
-        edge = RECT_BOTTOM(*a) + 1;
+        edge = RECT_BOTTOM(*a) + 1 - (config_margins_per_monitor ? config_margins.bottom : 0);
         break;
     case OB_DIRECTION_EAST:
-        edge = RECT_RIGHT(*a) + 1;
+        edge = RECT_RIGHT(*a) + 1 - (config_margins_per_monitor ? config_margins.right : 0);
         break;
     case OB_DIRECTION_WEST:
-        edge = RECT_LEFT(*a) - 1;
+        edge = RECT_LEFT(*a) - 1 + (config_margins_per_monitor ? config_margins.left : 0);
         break;
     default:
         g_assert_not_reached();
     }
-    /* default to the far edge, then narrow it down */
+    /* default to the far edge (per-monitor margin adjusted), then narrow it down */
     *dest = edge;
     *near_edge = TRUE;
 

--- a/openbox/config.c
+++ b/openbox/config.c
@@ -46,6 +46,7 @@ guint          config_primary_monitor_index;
 ObPlaceMonitor config_primary_monitor;
 
 StrutPartial config_margins;
+gboolean     config_margins_per_monitor;
 
 gchar   *config_theme;
 gboolean config_theme_keepborder;
@@ -688,6 +689,8 @@ static void parse_margins(xmlNodePtr node, gpointer d)
 {
     xmlNodePtr n;
 
+    obt_xml_attr_bool(node, "perMonitor", &config_margins_per_monitor);
+
     node = node->children;
 
     if ((n = obt_xml_find_node(node, "top")))
@@ -1119,6 +1122,7 @@ void config_startup(ObtXmlInst *i)
     obt_xml_register(i, "placement", parse_placement, NULL);
 
     STRUT_PARTIAL_SET(config_margins, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    config_margins_per_monitor = FALSE;
 
     obt_xml_register(i, "margins", parse_margins, NULL);
 

--- a/openbox/config.h
+++ b/openbox/config.h
@@ -106,6 +106,8 @@ extern ObPlaceMonitor config_primary_monitor;
 
 /*! User-specified margins around the edge of the screen(s) */
 extern StrutPartial config_margins;
+/*! When TRUE, margins are applied per-monitor instead of as global struts */
+extern gboolean config_margins_per_monitor;
 
 /*! When true windows' contents are refreshed while they are resized; otherwise
   they are not updated until the resize is complete */

--- a/openbox/screen.c
+++ b/openbox/screen.c
@@ -1678,13 +1678,6 @@ Rect* screen_area(guint desktop, guint head, Rect *search)
                 t = MAX(t, RECT_TOP(monitor_area[i]));
                 r = MIN(r, RECT_RIGHT(monitor_area[i]));
                 b = MIN(b, RECT_BOTTOM(monitor_area[i]));
-
-                if (config_margins_per_monitor) {
-                    l += config_margins.left;
-                    t += config_margins.top;
-                    r -= config_margins.right;
-                    b -= config_margins.bottom;
-                }
             }
         }
     }

--- a/openbox/screen.c
+++ b/openbox/screen.c
@@ -1482,14 +1482,16 @@ void screen_update_areas(void)
     if (dock_strut.bottom)
         ADD_STRUT_TO_LIST(struts_bottom, DESKTOP_ALL, &dock_strut);
 
-    if (config_margins.left)
-        ADD_STRUT_TO_LIST(struts_left, DESKTOP_ALL, &config_margins);
-    if (config_margins.top)
-        ADD_STRUT_TO_LIST(struts_top, DESKTOP_ALL, &config_margins);
-    if (config_margins.right)
-        ADD_STRUT_TO_LIST(struts_right, DESKTOP_ALL, &config_margins);
-    if (config_margins.bottom)
-        ADD_STRUT_TO_LIST(struts_bottom, DESKTOP_ALL, &config_margins);
+    if (!config_margins_per_monitor) {
+        if (config_margins.left)
+            ADD_STRUT_TO_LIST(struts_left, DESKTOP_ALL, &config_margins);
+        if (config_margins.top)
+            ADD_STRUT_TO_LIST(struts_top, DESKTOP_ALL, &config_margins);
+        if (config_margins.right)
+            ADD_STRUT_TO_LIST(struts_right, DESKTOP_ALL, &config_margins);
+        if (config_margins.bottom)
+            ADD_STRUT_TO_LIST(struts_bottom, DESKTOP_ALL, &config_margins);
+    }
 
     VALIDATE_STRUTS(struts_left, left,
                     monitor_area[screen_num_monitors].width / 2);
@@ -1676,6 +1678,13 @@ Rect* screen_area(guint desktop, guint head, Rect *search)
                 t = MAX(t, RECT_TOP(monitor_area[i]));
                 r = MIN(r, RECT_RIGHT(monitor_area[i]));
                 b = MIN(b, RECT_BOTTOM(monitor_area[i]));
+
+                if (config_margins_per_monitor) {
+                    l += config_margins.left;
+                    t += config_margins.top;
+                    r -= config_margins.right;
+                    b -= config_margins.bottom;
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem

The existing <margins> element applies a global strut across the entire desktop. On multi-monitor setups, left/right margins only affect the outermost screen edges, making it impossible to add consistent insets per monitor.

## Solution
A new perMonitor attribute on the existing <margins> element:

```xml
<margins perMonitor="yes">
    <top>8</top>
    <left>8</left>
    <right>8</right>
    <bottom>8</bottom>
</margins>
```

When perMonitor="yes", margins are no longer added as global struts. Instead they are applied per monitor inside screen_area() when a specific monitor head is requested, so they naturally propagate to all consumers:

Maximize (MaximizeFull, MaximizeVert, MaximizeHorz)
Snapping (MoveResizeTo, MoveToEdge)

Not affected: fullscreen windows (screen_physical_area_monitor is used there), floating windows. Panel struts (e.g. Polybar) are respected - they and the margins stack correctly.

The default (perMonitor="no") preserves existing behaviour exactly.

## Changes
- config.h/c - gboolean config_margins_per_monitor, read from the perMonitor attribute via obt_xml_attr_bool, defaults to FALSE
- screen.c - margins skipped as struts when perMonitor="yes"; instead applied in screen_area() inside the if (head == i) block after monitor clamping
- client.c - MoveToEdge initial fallback edge adjusted to the margin position when perMonitor="yes"
- data/rc.xml - sample config updated with perMonitor attribute and documentation

## Testing

Tested with Xephyr (single monitor) and a dual-monitor setup with Polybar strut on the bottom.